### PR TITLE
Add convert method for Gaussian-to-Gaussian conversion

### DIFF
--- a/src/GaussianDistributions.jl
+++ b/src/GaussianDistributions.jl
@@ -58,6 +58,8 @@ Gaussian() = Gaussian(0.0, 1.0)
 mean(P::Gaussian) = P.μ
 cov(P::Gaussian) = P.Σ
 var(P::Gaussian{<:Real}) = P.Σ
+Base.convert(::Type{Gaussian{T, S}}, g::Gaussian) where {T, S} =
+    Gaussian(convert(T, g.μ), convert(S, g.Σ))
      
 dim(P::Gaussian) = length(P.μ)
 whiten(Σ::PSD, z) = Σ.σ\z

--- a/test/gaussian.jl
+++ b/test/gaussian.jl
@@ -8,6 +8,12 @@ x = rand()
 σ = rand()
 Σ = σ*σ'
 
+# Check type conversions
+GFloat = Gaussian{Vector{Float64}, Matrix{Float64}}
+v = GFloat[Gaussian([1.0], eye(2)),
+           Gaussian(SVector(1.0), @SMatrix [1.0 0.0; 0.0 1.0])]
+@test mean.(v) == [[1.0], [1.0]]
+
 p = pdf(Normal(μ, √Σ), x)
 @test pdf(Gaussian(μ, Σ), x) ≈ p
 @test pdf(Gaussian(μ, Σ*I), x) ≈ p


### PR DESCRIPTION
This is to support that if I have a struct with field typed `Gaussian{Vector{Float64}, Matrix{Float64}}`, passing a `Gaussian{SVector{Float64}, SMatrix{Float64}}` will just invoke the conversion.