### PR TITLE
More 0.7 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ os:
   - osx
 julia:
   - 0.6
+  - '0.7'
+  - '1.0'
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
   - '0.7'
   - '1.0'
   - nightly

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6
+julia 0.7
 Distributions

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,5 @@
 julia 0.6
 Distributions
+LinearAlgebra
+Statistics
+Random

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,2 @@
 julia 0.6
 Distributions
-LinearAlgebra
-Statistics
-Random

--- a/src/GaussianDistributions.jl
+++ b/src/GaussianDistributions.jl
@@ -6,7 +6,7 @@ using LinearAlgebra, Random, Statistics
 using Distributions
 using LinearAlgebra: norm_sqr
 
-import Random: rand
+import Random: rand, GLOBAL_RNG
 import Statistics: mean, cov, var
 import Distributions: pdf, logpdf, sqmahal, cdf, quantile
 import LinearAlgebra: cholesky
@@ -109,8 +109,8 @@ rand(RNG::AbstractRNG, P::Gaussian, dims::Tuple{Vararg{Int64,N}} where N) = rand
 
 rand(RNG::AbstractRNG, P::Gaussian{Vector{T}}, dim::Integer) where {T} = rand_vector(RNG, P, dim)
 rand(RNG::AbstractRNG, P::Gaussian{Vector{T}}, dims::Tuple{Vararg{Int64,N}} where N) where {T} = rand_vector(RNG, P, dims)
-rand(P::Gaussian, dims::Tuple{Vararg{Int64,N}} where N) = rand(Base.GLOBAL_RNG, P, dims)
-rand(P::Gaussian, dim::Integer) = rand(Base.GLOBAL_RNG, P, dim)
+rand(P::Gaussian, dims::Tuple{Vararg{Int64,N}} where N) = rand(GLOBAL_RNG, P, dims)
+rand(P::Gaussian, dim::Integer) = rand(GLOBAL_RNG, P, dim)
 
 """
     logpdfnormal(x, Σ) 

--- a/src/GaussianDistributions.jl
+++ b/src/GaussianDistributions.jl
@@ -23,8 +23,7 @@ struct PSD{T}
     σ::T
     PSD(σ::T) where {T} = istril(σ) ? new{T}(σ) : throw(ArgumentError("Argument not lower triangular"))
 end
-Base.chol(P::PSD) = P.σ' 
-#cholesky(P::PSD) = (U=P.σ',)   # using a named tuple for now. FIXME? 
+cholesky(P::PSD) = (U=P.σ',)   # using a named tuple for now. FIXME? Also: TESTME
 
 """
 Sum of the log of the diagonal elements. Second argument `d` is used
@@ -67,8 +66,8 @@ Base.convert(::Type{Gaussian{T, S}}, g::Gaussian) where {T, S} =
      
 dim(P::Gaussian) = length(P.μ)
 whiten(Σ::PSD, z) = Σ.σ\z
-#whiten(Σ, z) = cholesky(Σ).U'\z
-whiten(Σ, z) = chol(Σ)'\z
+whiten(Σ, z) = cholesky(Σ).U'\z
+whiten(Σ::Number, z) = sqrt(Σ)\z
 whiten(Σ::UniformScaling, z) = z/sqrt(Σ.λ)
 sqmahal(P::Gaussian, x) = norm_sqr(whiten(P.Σ, x .- P.μ))
 

--- a/src/GaussianDistributions.jl
+++ b/src/GaussianDistributions.jl
@@ -2,12 +2,15 @@ __precompile__()
 module GaussianDistributions
 
 # Gaussian
+using LinearAlgebra, Random, Statistics
 using Distributions
-using Base.LinAlg: norm_sqr
+using LinearAlgebra: norm_sqr
 
-import Base: rand, mean, cov, var
+import Random: rand
+import Statistics: mean, cov, var
 import Distributions: pdf, logpdf, sqmahal, cdf, quantile
-import Base: chol, size
+import LinearAlgebra: cholesky
+import Base: size
 
 export PSD, Gaussian
 
@@ -20,7 +23,8 @@ struct PSD{T}
     σ::T
     PSD(σ::T) where {T} = istril(σ) ? new{T}(σ) : throw(ArgumentError("Argument not lower triangular"))
 end
-chol(P::PSD) = P.σ' 
+Base.chol(P::PSD) = P.σ' 
+#cholesky(P::PSD) = (U=P.σ',)   # using a named tuple for now. FIXME? 
 
 """
 Sum of the log of the diagonal elements. Second argument `d` is used
@@ -63,22 +67,25 @@ Base.convert(::Type{Gaussian{T, S}}, g::Gaussian) where {T, S} =
      
 dim(P::Gaussian) = length(P.μ)
 whiten(Σ::PSD, z) = Σ.σ\z
+#whiten(Σ, z) = cholesky(Σ).U'\z
 whiten(Σ, z) = chol(Σ)'\z
 whiten(Σ::UniformScaling, z) = z/sqrt(Σ.λ)
-sqmahal(P::Gaussian, x) = norm_sqr(whiten(P.Σ, x - P.μ))
+sqmahal(P::Gaussian, x) = norm_sqr(whiten(P.Σ, x .- P.μ))
 
-rand(P::Gaussian) = P.μ + chol(P.Σ)'*randn(typeof(P.μ))
+rand(P::Gaussian) = P.μ + cholesky(P.Σ).U'*randn(typeof(P.μ))
 rand(P::Gaussian{Vector{T}}) where T =
-    P.μ + chol(P.Σ)'*randn(T, length(P.μ))
-rand(RNG::AbstractRNG, P::Gaussian) = P.μ + chol(P.Σ)'*randn(RNG, typeof(P.μ))
+    P.μ + cholesky(P.Σ).U'*randn(T, length(P.μ))
+rand(P::Gaussian{<:Number}) = P.μ + randn(typeof(P.μ)) * sqrt(P.Σ)
+rand(RNG::AbstractRNG, P::Gaussian) = P.μ + cholesky(P.Σ).U'*randn(RNG, typeof(P.μ))
 rand(RNG::AbstractRNG, P::Gaussian{Vector{T}}) where T =
-    P.μ + chol(P.Σ)'*randn(RNG, T, length(P.μ))
+    P.μ + cholesky(P.Σ).U'*randn(RNG, T, length(P.μ))
+rand(RNG::AbstractRNG, P::Gaussian{<:Number}) = P.μ + randn(RNG, typeof(P.μ)) * sqrt(P.Σ)
 
 logpdf(P::Gaussian, x) = -(sqmahal(P,x) + _logdet(P.Σ, dim(P)) + dim(P)*log(2pi))/2    
 pdf(P::Gaussian, x) = exp(logpdf(P::Gaussian, x))
 cdf(P::Gaussian{Number}, x) = Distributions.normcdf(P.μ, sqrt(P.Σ), x)
 
-Base.:+(g::Gaussian, vec) = Gaussian(g.μ + vec, g.Σ)
+Base.:+(g::Gaussian, vec) = Gaussian(g.μ .+ vec, g.Σ)
 Base.:+(vec, g::Gaussian) = g + vec
 Base.:-(g::Gaussian, vec) = g + (-vec)
 Base.:*(M, g::Gaussian) = Gaussian(M * g.μ, M * g.Σ * M')
@@ -113,7 +120,7 @@ Logarithm of the probability density function of centered Gaussian with covarian
 """
 function logpdfnormal(x, Σ) 
 
-    S = chol(_symmetric(Σ))'
+    S = cholesky(_symmetric(Σ)).U'
 
     d = length(x)
      -((norm(S\x))^2 + 2sumlogdiag(S,d) + d*log(2pi))/2

--- a/test/bivariate.jl
+++ b/test/bivariate.jl
@@ -64,7 +64,7 @@ data = [
     -0.5410899301286479 1.6557106424466033 0.9509727243269613 0.29422279933864653
 ]
 for i in 1:size(data, 1)
-    x, y, ρ, pr = data[i, :]
+    local x, y, ρ, pr = data[i, :]
     @test GaussianDistributions.Phi(x, y, ρ) ≈ pr
 end
 

--- a/test/gaussian.jl
+++ b/test/gaussian.jl
@@ -1,3 +1,5 @@
+import Random
+using Random: MersenneTwister
 using Distributions
 using Test
 using StaticArrays
@@ -23,11 +25,11 @@ p = pdf(Normal(μ, √Σ), x)
 @test pdf(Gaussian((@SVector [μ]), @SMatrix [Σ]), @SVector [x]) ≈ p
 
 for d in 1: 3
-    μ = rand(d)
-    x = rand(d)
-    σ = tril(rand(d,d))
-    Σ = σ*σ'
-    p = pdf(MvNormal(μ, Σ), x)
+    local μ = rand(d)
+    local x = rand(d)
+    local σ = tril(rand(d,d))
+    local Σ = σ*σ'
+    local p = pdf(MvNormal(μ, Σ), x)
 
     @test pdf(Gaussian(μ, Σ), x) ≈ p
     @test pdf(Gaussian(μ, PSD(σ)), x) ≈ p
@@ -39,24 +41,24 @@ for d in 1: 3
     local μ = rand(d)
     local x = rand(d)
     local σ = rand()
-    Σ = Matrix(1.0I, d, d).*σ^2
-    p = pdf(MvNormal(μ, Σ), x)
+    local Σ = Matrix(1.0I, d, d).*σ^2
+    local p = pdf(MvNormal(μ, Σ), x)
 
     @test pdf(Gaussian(μ, σ^2*I), x) ≈ p
     @test pdf(Gaussian(SVector{d}(μ), SDiagonal(σ^2*ones(SVector{d}))), x) ≈ p
     @test pdf(Gaussian(SVector{d}(μ), SMatrix{d,d}(Σ)), x) ≈ p
 end
 
-@test rand(Base.Random.GLOBAL_RNG, Gaussian(1.0, 0.0)) == 1.0
+@test rand(Random.GLOBAL_RNG, Gaussian(1.0, 0.0)) == 1.0
 @test mean(rand(MersenneTwister(1), Gaussian([1., 2], Matrix(1.0I, 2, 2)), 100000)) ≈ 1.5 atol=0.02
 
 @test rand(Gaussian(1.0,0.0)) == 1.0
-srand(5)
+Random.seed!(5)
 x = randn()
-srand(5)
+Random.seed!(5)
 @test rand(Gaussian(1.0,2.0)) == 1.0 .+ sqrt(2)*x
 
-srand(5)
+Random.seed!(5)
 @test rand(Gaussian(1.0,2.0), (1,)) == [1.0 + sqrt(2)*x]
 
 g = Gaussian([1,2], Matrix(1.0I, 2, 2))

--- a/test/gaussian.jl
+++ b/test/gaussian.jl
@@ -1,6 +1,7 @@
 using Distributions
-using Base.Test
+using Test
 using StaticArrays
+using LinearAlgebra
 
 
 μ = rand()
@@ -10,7 +11,7 @@ x = rand()
 
 # Check type conversions
 GFloat = Gaussian{Vector{Float64}, Matrix{Float64}}
-v = GFloat[Gaussian([1.0], eye(2)),
+v = GFloat[Gaussian([1.0], Matrix(1.0I, 2, 2)),
            Gaussian(SVector(1.0), @SMatrix [1.0 0.0; 0.0 1.0])]
 @test mean.(v) == [[1.0], [1.0]]
 
@@ -35,10 +36,10 @@ for d in 1: 3
 end
 
 for d in 1: 3
-    μ = rand(d)
-    x = rand(d)
-    σ = rand()
-    Σ = eye(d)*σ^2
+    local μ = rand(d)
+    local x = rand(d)
+    local σ = rand()
+    Σ = Matrix(1.0I, d, d).*σ^2
     p = pdf(MvNormal(μ, Σ), x)
 
     @test pdf(Gaussian(μ, σ^2*I), x) ≈ p
@@ -47,18 +48,18 @@ for d in 1: 3
 end
 
 @test rand(Base.Random.GLOBAL_RNG, Gaussian(1.0, 0.0)) == 1.0
-@test mean(rand(MersenneTwister(1), Gaussian([1., 2], eye(2)), 100000)) ≈ 1.5 atol=0.02
+@test mean(rand(MersenneTwister(1), Gaussian([1., 2], Matrix(1.0I, 2, 2)), 100000)) ≈ 1.5 atol=0.02
 
 @test rand(Gaussian(1.0,0.0)) == 1.0
 srand(5)
 x = randn()
 srand(5)
-@test rand(Gaussian(1.0,2.0)) == 1.0 + sqrt(2)*x
+@test rand(Gaussian(1.0,2.0)) == 1.0 .+ sqrt(2)*x
 
 srand(5)
 @test rand(Gaussian(1.0,2.0), (1,)) == [1.0 + sqrt(2)*x]
 
-g = Gaussian([1,2], eye(2))
+g = Gaussian([1,2], Matrix(1.0I, 2, 2))
 @test mean(g + 10) == [11,12]
 @test g - 10 + 10 == g
 @test mean(g + [10, 20]) == [11,22]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using GaussianDistributions
-using Base.Test
+using Test
 
 include("gaussian.jl")
 include("bivariate.jl")


### PR DESCRIPTION
Most of it is straight-forward, but `cholesky(P.Σ).U` is not a fantastic `chol` replacement, even though that's what the deprecation warning recommends. In particular, `cholesky(::Number).U` is a 1x1 matrix, so I had to special-case it in a number of places.

Also of note: `cholesky(P::PSD) = (U=P.σ',)`. I'm not a big linear-algebra guy, so that may not make sense at all. It's not tested at the moment; that should probably be fixed.