### PR TITLE
Support 1D Gaussian with units

### DIFF
--- a/src/GaussianDistributions.jl
+++ b/src/GaussianDistributions.jl
@@ -71,14 +71,11 @@ whiten(Σ::Number, z) = sqrt(Σ)\z
 whiten(Σ::UniformScaling, z) = z/sqrt(Σ.λ)
 sqmahal(P::Gaussian, x) = norm_sqr(whiten(P.Σ, x .- P.μ))
 
-rand(P::Gaussian) = P.μ + cholesky(P.Σ).U'*randn(typeof(P.μ))
-rand(P::Gaussian{Vector{T}}) where T =
-    P.μ + cholesky(P.Σ).U'*randn(T, length(P.μ))
-rand(P::Gaussian{<:Number}) = P.μ + randn(typeof(P.μ)) * sqrt(P.Σ)
+rand(P::Gaussian) = rand(GLOBAL_RNG, P)
 rand(RNG::AbstractRNG, P::Gaussian) = P.μ + cholesky(P.Σ).U'*randn(RNG, typeof(P.μ))
 rand(RNG::AbstractRNG, P::Gaussian{Vector{T}}) where T =
     P.μ + cholesky(P.Σ).U'*randn(RNG, T, length(P.μ))
-rand(RNG::AbstractRNG, P::Gaussian{<:Number}) = P.μ + randn(RNG, typeof(P.μ)) * sqrt(P.Σ)
+rand(RNG::AbstractRNG, P::Gaussian{<:Number}) = P.μ + randn(RNG, typeof(one(P.μ))) * sqrt(P.Σ)
 
 logpdf(P::Gaussian, x) = -(sqmahal(P,x) + _logdet(P.Σ, dim(P)) + dim(P)*log(2pi))/2    
 pdf(P::Gaussian, x) = exp(logpdf(P::Gaussian, x))

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 StaticArrays
+Unitful

--- a/test/gaussian.jl
+++ b/test/gaussian.jl
@@ -4,6 +4,7 @@ using Distributions
 using Test
 using StaticArrays
 using LinearAlgebra
+using Unitful
 
 
 μ = rand()
@@ -51,6 +52,7 @@ end
 
 @test rand(Random.GLOBAL_RNG, Gaussian(1.0, 0.0)) == 1.0
 @test mean(rand(MersenneTwister(1), Gaussian([1., 2], Matrix(1.0I, 2, 2)), 100000)) ≈ 1.5 atol=0.02
+@test mean(rand(MersenneTwister(1), Gaussian(1.5u"m", 2.0u"m^2"), 100000)) ≈ 1.5u"m" atol=0.02u"m"
 
 @test rand(Gaussian(1.0,0.0)) == 1.0
 Random.seed!(5)


### PR DESCRIPTION
`cholesky([1 0; 0 1].*u"m")` isn't implemented, so for now, only 1D Gaussian works.